### PR TITLE
Fix tech debt: add CI linting, fix clippy warnings, align dependencies

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,8 +11,25 @@ env:
   COVERAGE_THRESHOLD: 85
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+      - name: Run clippy
+        run: cargo clippy --workspace --all-features -- -D warnings
+
   build:
     runs-on: ubuntu-latest
+    needs: lint
     steps:
       - uses: actions/checkout@v4
 
@@ -24,6 +41,7 @@ jobs:
 
   coverage:
     runs-on: ubuntu-latest
+    needs: lint
     steps:
       - uses: actions/checkout@v4
 
@@ -38,6 +56,7 @@ jobs:
 
   benchmarks:
     runs-on: ubuntu-latest
+    needs: lint
     steps:
       - uses: actions/checkout@v4
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.1.0"
 edition = "2021"
 
 [workspace.dependencies]
-ndarray = "0.15"
+ndarray = "0.16"
 ndarray-rand = "0.14"
 thiserror = "1.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -6,7 +6,7 @@ edition.workspace = true
 [lib]
 
 [dependencies]
-ndarray = { version = "0.16", optional = true }
+ndarray = { workspace = true, optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 bincode = { version = "1.3", optional = true }
 rand = { version = "0.8", features = ["small_rng"] }

--- a/lib/src/backend/ndarray_backend.rs
+++ b/lib/src/backend/ndarray_backend.rs
@@ -1,4 +1,3 @@
-use super::Backend;
 use ndarray::{Array1, Array2, Ix1};
 
 /// CPU-based tensor backend implementation using the `ndarray` crate.
@@ -72,9 +71,7 @@ impl super::Backend for NdarrayBackend {
     type Device = (); // CPU-only for now
 
     /// Returns the default device for this backend (unit type for CPU execution).
-    fn default_device() -> Self::Device {
-        ()
-    }
+    fn default_device() -> Self::Device {}
 
     /// Creates a 1D tensor filled with zeros.
     ///
@@ -788,6 +785,7 @@ impl super::Backend for NdarrayBackend {
 #[cfg(feature = "ndarray")]
 mod tests {
     use super::*;
+    use crate::backend::Backend;
     use ndarray::{Array1, Array2};
 
     // Helper to create 2D tensor from nested vec


### PR DESCRIPTION
- Add clippy and rustfmt checks to CI workflow with -D warnings
- Remove unused import `super::Backend` in ndarray_backend.rs
- Fix clippy warning: remove unneeded unit expression in default_device()
- Add missing Backend trait import in ndarray_backend tests
- Align ndarray version to 0.16 across workspace and lib
- Use workspace.dependencies for ndarray in lib/Cargo.toml