### PR TITLE
docs(specs): backfill OpenSpec specs for existing capabilities

### DIFF
--- a/openspec/specs/loss-functions/spec.md
+++ b/openspec/specs/loss-functions/spec.md
@@ -1,0 +1,58 @@
+## EXISTING Requirements
+
+### Requirement: MSE Loss
+
+MSE (Mean Squared Error) loss SHALL compute the average squared difference between predictions and targets.
+
+#### Scenario: MSE loss computation
+
+- **WHEN** predictions are `[3.0, 5.0]` and targets are `[1.0, 2.0]`
+- **THEN** loss equals `((3-1)² + (5-2)²) / 2 = 6.5`
+
+#### Scenario: MSE gradient computation
+
+- **WHEN** computing gradient w.r.t. predictions
+- **THEN** gradient equals `(prediction - target) / n`
+
+### Requirement: MAE Loss
+
+MAE (Mean Absolute Error) loss SHALL compute the average absolute difference between predictions and targets.
+
+#### Scenario: MAE loss computation
+
+- **WHEN** predictions are `[3.0, -1.0]` and targets are `[1.0, 2.0]`
+- **THEN** loss equals `(|3-1| + |-1-2|) / 2 = 2.5`
+
+#### Scenario: MAE gradient computation
+
+- **WHEN** computing gradient w.r.t. predictions
+- **THEN** gradient equals `sign(prediction - target) / n`
+
+### Requirement: BCE With Logits Loss
+
+BCEWithLogitsLoss SHALL compute binary cross-entropy with numerical stability using the log-sum-exp trick.
+
+#### Scenario: BCE loss is numerically stable
+
+- **WHEN** logits are very large (`100.0`) or very small (`-100.0`)
+- **THEN** loss value is finite (no overflow/underflow)
+- **AND** gradients are finite
+
+#### Scenario: BCE gradient computation
+
+- **WHEN** computing gradient w.r.t. logits
+- **THEN** gradient equals `(sigmoid(logits) - targets) / n`
+
+### Requirement: Loss Trait Interface
+
+All loss functions SHALL implement the `Loss<B>` trait with `loss()` and `grad_wrt_prediction()` methods.
+
+#### Scenario: Loss returns scalar
+
+- **WHEN** `loss()` is called
+- **THEN** return type is `Scalar<B>`
+
+#### Scenario: Gradient returns prediction type
+
+- **WHEN** `grad_wrt_prediction()` is called
+- **THEN** return type matches the prediction type

--- a/openspec/specs/model-selection/spec.md
+++ b/openspec/specs/model-selection/spec.md
@@ -1,0 +1,73 @@
+## EXISTING Requirements
+
+### Requirement: Train-Test Split
+
+train_test_split SHALL divide a dataset into training and testing subsets.
+
+#### Scenario: Default split ratio
+
+- **WHEN** train_test_split is called with default parameters
+- **THEN** approximately 75% of data is in train set
+- **AND** approximately 25% is in test set
+
+#### Scenario: Custom test size
+
+- **WHEN** train_test_split is called with `test_size=0.2`
+- **THEN** 20% of data is in test set
+
+#### Scenario: Stratified split
+
+- **WHEN** stratified split is requested
+- **THEN** class distribution is preserved in both train and test sets
+
+#### Scenario: Random state reproducibility
+
+- **WHEN** same random_state is used
+- **THEN** identical splits are produced
+
+### Requirement: K-Fold Cross-Validation
+
+KFold SHALL split data into k consecutive folds for cross-validation.
+
+#### Scenario: K-fold splits
+
+- **WHEN** KFold with k=5 is created
+- **THEN** 5 different train/test split pairs are generated
+- **AND** each sample appears in test set exactly once
+
+#### Scenario: K-fold no overlap
+
+- **WHEN** KFold generates splits
+- **THEN** train and test sets are disjoint
+
+### Requirement: Grid Search
+
+GridSearchCV SHALL exhaustively search over specified parameter values.
+
+#### Scenario: Grid search finds best params
+
+- **WHEN** GridSearchCV is run with parameter grid
+- **THEN** best_params_ contains the combination with highest cross-validation score
+
+#### Scenario: Grid search with cross-validation
+
+- **WHEN** GridSearchCV with cv=5 is run
+- **THEN** each parameter combination is evaluated with 5-fold cross-validation
+
+### Requirement: Pipeline Grid Search
+
+Grid search SHALL support pipelines with parameter references using `__` notation.
+
+#### Scenario: Pipeline parameter grid
+
+- **WHEN** parameter grid contains `"scaler__with_mean": [True, False]`
+- **THEN** grid search varies the scaler's with_mean parameter
+
+### Requirement: Cross-Validation Scoring
+
+Cross-validation SHALL support multiple scoring metrics.
+
+#### Scenario: Multiple metrics
+
+- **WHEN** scoring is set to `['r2', 'neg_mean_squared_error']`
+- **THEN** results contain scores for both metrics

--- a/openspec/specs/model-training/spec.md
+++ b/openspec/specs/model-training/spec.md
@@ -1,0 +1,56 @@
+## EXISTING Requirements
+
+### Requirement: Type-State Model Safety
+
+Models SHALL use phantom type-state to enforce compile-time guarantees about training status.
+
+#### Scenario: Unfitted model cannot predict
+
+- **WHEN** a model is in `Unfitted` state
+- **THEN** `predict()` method is not available at compile time
+- **AND** only `forward()`, `backward()`, and `update_params()` are available
+
+#### Scenario: Fitted model cannot train
+
+- **WHEN** a model is in `Fitted` state
+- **THEN** `forward()`, `backward()`, and `update_params()` are not available
+- **AND** only `predict()` and `predict_batch()` are available
+
+### Requirement: Linear Model Forward Pass
+
+The linear model SHALL compute predictions as `y = X @ w + b`.
+
+#### Scenario: Forward pass with 2D input
+
+- **WHEN** input `X` has shape `(n_samples, n_features)` and weights have shape `(n_features,)`
+- **THEN** output has shape `(n_samples,)`
+- **AND** output values are `X @ w + b`
+
+### Requirement: Linear Model Backward Pass
+
+The linear model SHALL compute gradients for weights and bias.
+
+#### Scenario: Backward pass gradient shapes
+
+- **WHEN** backward is called with gradient of shape `(n_samples,)` and input of shape `(n_samples, n_features)`
+- **THEN** weight gradient has shape `(n_features,)`
+- **AND** bias gradient is a scalar
+
+### Requirement: Model Serialization
+
+Fitted models SHALL be serializable to and from files.
+
+#### Scenario: Save and load round-trip
+
+- **WHEN** a fitted model is saved to file and loaded back
+- **THEN** the loaded model produces identical predictions
+
+### Requirement: Inference Model Separation
+
+A fitted model SHALL contain only inference parameters with no optimizer state or loss functions.
+
+#### Scenario: Fitted model is lightweight
+
+- **WHEN** a model is converted to fitted state via `into_fitted()`
+- **THEN** the resulting model contains only weights and bias
+- **AND** no learning rate, loss function, or training metadata is retained

--- a/openspec/specs/preprocessing-encoding/spec.md
+++ b/openspec/specs/preprocessing-encoding/spec.md
@@ -1,0 +1,52 @@
+## EXISTING Requirements
+
+### Requirement: OneHotEncoder
+
+OneHotEncoder SHALL convert categorical integer values to one-hot encoded vectors.
+
+#### Scenario: One-hot encoding basic
+
+- **WHEN** input column contains categories `[0, 1, 2]`
+- **THEN** output is 3 columns with one-hot encoding
+
+#### Scenario: One-hot encoding multi-column
+
+- **WHEN** input has 2 columns with 3 and 2 categories respectively
+- **THEN** output has `3 + 2 = 5` columns
+
+#### Scenario: One-hot handle unknown
+
+- **WHEN** unknown category is encountered during transform and `handle_unknown='ignore'`
+- **THEN** all output columns for that sample are zero
+
+### Requirement: OrdinalEncoder
+
+OrdinalEncoder SHALL convert categorical values to integer ordinals.
+
+#### Scenario: Ordinal encoding
+
+- **WHEN** categories are `["low", "medium", "high"]`
+- **THEN** they are mapped to `[0, 1, 2]`
+
+### Requirement: LabelEncoder
+
+LabelEncoder SHALL encode target labels with values between 0 and n_classes-1.
+
+#### Scenario: Label encoding targets
+
+- **WHEN** target values are `["cat", "dog", "cat", "bird"]`
+- **THEN** encoded values are `[0, 1, 0, 2]` (or similar mapping)
+
+#### Scenario: Label encoder inverse transform
+
+- **WHEN** inverse_transform is called on encoded labels
+- **THEN** original string labels are returned
+
+### Requirement: Encoder Serialization
+
+All encoders SHALL be serializable via their params representation.
+
+#### Scenario: Encoder save/load
+
+- **WHEN** a fitted encoder is saved and loaded
+- **THEN** it produces identical encodings

--- a/openspec/specs/preprocessing-scaling/spec.md
+++ b/openspec/specs/preprocessing-scaling/spec.md
@@ -1,0 +1,75 @@
+## EXISTING Requirements
+
+### Requirement: StandardScaler
+
+StandardScaler SHALL transform features to zero mean and unit variance using `z = (x - mean) / std`.
+
+#### Scenario: StandardScaler fit
+
+- **WHEN** StandardScaler is fit on data with columns having different means and stds
+- **THEN** learned mean_ and std_ match column-wise statistics
+
+#### Scenario: StandardScaler transform
+
+- **WHEN** data is transformed by fitted StandardScaler
+- **THEN** output columns have approximately zero mean and unit variance
+
+#### Scenario: StandardScaler with_mean=false
+
+- **WHEN** StandardScaler is configured with `with_mean=false`
+- **THEN** data is scaled but not centered
+
+### Requirement: MinMaxScaler
+
+MinMaxScaler SHALL transform features to a given range (default [0, 1]).
+
+#### Scenario: MinMaxScaler default range
+
+- **WHEN** MinMaxScaler is fit and transform is applied
+- **THEN** all values are in range [0, 1]
+
+#### Scenario: MinMaxScaler custom range
+
+- **WHEN** MinMaxScaler is configured with `feature_range=(a, b)`
+- **THEN** all transformed values are in range [a, b]
+
+### Requirement: RobustScaler
+
+RobustScaler SHALL use median and IQR for scaling, robust to outliers.
+
+#### Scenario: RobustScaler ignores outliers
+
+- **WHEN** data contains extreme outliers
+- **THEN** RobustScaler centering/scaling is less affected than StandardScaler
+
+### Requirement: MaxAbsScaler
+
+MaxAbsScaler SHALL scale by maximum absolute value, preserving sparsity.
+
+#### Scenario: MaxAbsScaler preserves zeros
+
+- **WHEN** input data contains zeros
+- **THEN** transformed data still contains zeros
+
+### Requirement: Normalizer
+
+Normalizer SHALL scale individual samples to unit norm (L1, L2, or Max).
+
+#### Scenario: L2 normalization
+
+- **WHEN** Normalizer with L2 norm is applied to sample `[3.0, 4.0]`
+- **THEN** result is `[0.6, 0.8]` (unit L2 norm)
+
+### Requirement: Transformer Trait Interface
+
+All scalers SHALL implement `Transformer` and `FittedTransformer` traits.
+
+#### Scenario: Fit-transform separation
+
+- **WHEN** a scaler is fit on training data
+- **THEN** the same fitted scaler can transform multiple datasets
+
+#### Scenario: Inverse transform
+
+- **WHEN** `inverse_transform` is called on transformed data
+- **THEN** result approximates original data

--- a/openspec/specs/regularizers/spec.md
+++ b/openspec/specs/regularizers/spec.md
@@ -1,0 +1,63 @@
+## EXISTING Requirements
+
+### Requirement: L2 Regularization
+
+L2 (Ridge) regularizer SHALL compute penalty as `λ * ||w||²` with gradient `2λw`.
+
+#### Scenario: L2 penalty computation
+
+- **WHEN** weights are `[3.0, 4.0]` and lambda is `0.5`
+- **THEN** penalty equals `0.5 * (3² + 4²) = 12.5`
+
+#### Scenario: L2 gradient computation
+
+- **WHEN** weights are `[3.0, 4.0]` and lambda is `0.5`
+- **THEN** weight gradient equals `2 * 0.5 * [3.0, 4.0] = [3.0, 4.0]`
+
+### Requirement: L1 Regularization
+
+L1 (Lasso) regularizer SHALL compute penalty as `λ * ||w||₁` with gradient `λ * sign(w)`.
+
+#### Scenario: L1 penalty computation
+
+- **WHEN** weights are `[3.0, 4.0]` and lambda is `0.5`
+- **THEN** penalty equals `0.5 * (|3| + |4|) = 3.5`
+
+#### Scenario: L1 gradient computation
+
+- **WHEN** weights are `[3.0, -4.0]` and lambda is `0.5`
+- **THEN** weight gradient equals `0.5 * [1.0, -1.0] = [0.5, -0.5]`
+
+#### Scenario: L1 gradient at zero
+
+- **WHEN** a weight is `0.0`
+- **THEN** its gradient is `0.0` (subgradient at zero)
+
+### Requirement: Bias Not Regularized
+
+Regularizers SHALL NOT apply penalty or gradient to bias term.
+
+#### Scenario: Bias gradient is always zero
+
+- **WHEN** any regularizer is applied
+- **THEN** the bias gradient component is `0.0`
+
+### Requirement: No Regularizer
+
+NoRegularizer SHALL return zero penalty and zero gradients.
+
+#### Scenario: No regularization
+
+- **WHEN** NoRegularizer is used
+- **THEN** penalty is `0.0`
+- **AND** all gradients are zero
+
+### Requirement: Regularizer Trait Interface
+
+All regularizers SHALL implement `Regularizer<B, M>` trait returning `(Scalar<B>, M::Gradients)`.
+
+#### Scenario: Regularizer returns penalty and gradients
+
+- **WHEN** `regularizer_penalty_grad()` is called
+- **THEN** first element is scalar penalty value
+- **AND** second element is gradient structure matching model's gradient type

--- a/openspec/specs/sgd-optimizer/spec.md
+++ b/openspec/specs/sgd-optimizer/spec.md
@@ -1,0 +1,43 @@
+## EXISTING Requirements
+
+### Requirement: SGD Update Rule
+
+SGD (Stochastic Gradient Descent) SHALL update parameters using `params_new = params - lr * gradients`.
+
+#### Scenario: SGD step with positive gradients
+
+- **WHEN** params are `[2.0, 3.0]`, gradients are `[1.0, -1.0]`, and learning rate is `0.1`
+- **THEN** new params are `[2.0 - 0.1*1.0, 3.0 - 0.1*(-1.0)] = [1.9, 3.1]`
+
+#### Scenario: SGD step with zero learning rate
+
+- **WHEN** learning rate is `0.0`
+- **THEN** parameters remain unchanged
+
+### Requirement: SGD Immutability
+
+SGD step SHALL NOT mutate input parameters.
+
+#### Scenario: Original params preserved
+
+- **WHEN** `step()` is called with params and gradients
+- **THEN** original params and gradients are unchanged
+- **AND** new params are returned as a new value
+
+### Requirement: SGD Learning Rate Access
+
+SGD SHALL provide access to the current learning rate.
+
+#### Scenario: Learning rate getter
+
+- **WHEN** `learning_rate()` is called on SGD with lr=0.01
+- **THEN** return value is `0.01`
+
+### Requirement: SGD Clone
+
+SGD SHALL be clonable with identical behavior.
+
+#### Scenario: Cloned optimizer produces same updates
+
+- **WHEN** SGD is cloned
+- **THEN** both optimizers produce identical parameter updates


### PR DESCRIPTION
## Summary
Backfill OpenSpec specs documenting existing capabilities in the codebase:

| Spec | Coverage |
|------|----------|
| model-training | Type-state safety, linear model, serialization |
| loss-functions | MSE, MAE, BCEWithLogits |
| sgd-optimizer | SGD update rule, immutability |
| regularizers | L1, L2, NoRegularizer |
| preprocessing-scaling | Standard, MinMax, Robust, MaxAbs, Normalizer |
| preprocessing-encoding | OneHot, Ordinal, Label encoders |
| model-selection | train_test_split, KFold, GridSearchCV |

These specs use `EXISTING` requirements to document current behavior as a baseline for future changes.

## Why
- Provides reference documentation for existing features
- Creates baseline for tracking future changes
- Keeps context in one place alongside ADRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)